### PR TITLE
icyci/results: Force push source branch to results repo

### DIFF
--- a/icyci.go
+++ b/icyci.go
@@ -391,7 +391,9 @@ func pushResults(ch chan<- error, sourceDir string,
 		gitArgs := []string{"push", resultsRemote, res.ns,
 			stdoutNotesRef, stderrNotesRef}
 		if pushSrcToRslts {
-			gitArgs = append(gitArgs, "HEAD:refs/heads/"+branch)
+			// force push because 'branch' we fetched previously
+			// may be rebased, i.e. non-fast-forward
+			gitArgs = append(gitArgs, "+HEAD:refs/heads/"+branch)
 			if tag != "" {
 				gitArgs = append(gitArgs, "refs/tags/"+tag)
 			}


### PR DESCRIPTION
The source branch may be rebased in the source repo and pushing such a branch to the results repo (2nd and more time) will fail. Do a force push, in the case source repo == results repo the forced push should make any harm.